### PR TITLE
Web Audio API changes and gh-pages branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ browser supporting the Media Stream API is needed.
 There are three different audio graphic representations for fun, just drag the sliders and enjoy!
 
 ![Waveform screenshot](https://raw.githubusercontent.com/urtzurd/html-audio/master/static/img/screenshot.png "Screenshot of the waveform display")
+
+Live Demo
+=========
+A live demo can be found here: <a href="http://donkarlssonsan.github.io/html-audio/static/pitch-shifter.html">http://donkarlssonsan.github.io/html-audio/static/pitch-shifter.html</a>.

--- a/static/js/pitch-shifter.js
+++ b/static/js/pitch-shifter.js
@@ -73,7 +73,7 @@ var pitchShifter = (function () {
                 audioSources[0].buffer = bufferList[0];
                 audioSources[0].loop = true;
                 audioSources[0].connect(pitchShifterProcessor);
-                audioSources[0].noteOn(0);
+                audioSources[0].start(0);
             }
         );
 
@@ -320,9 +320,7 @@ var pitchShifter = (function () {
 
         init: function () {
 
-            if ('webkitAudioContext' in window) {
-                audioContext = new webkitAudioContext();
-            } else if ('AudioContext' in window) {
+            if ('AudioContext' in window) {
                 audioContext = new AudioContext();
             } else {
                 alert('Your browser does not support the Web Audio API');

--- a/static/pitch-shifter.html
+++ b/static/pitch-shifter.html
@@ -45,7 +45,8 @@
 
         <canvas width="512px" height="240px"></canvas>
 
-        <p>This page needs a <a href="https://dvcs.w3.org/hg/audio/raw-file/tip/webaudio/specification.html">Web Audio API</a> enabled browser, currently only <a href="http://support.google.com/chrome/bin/answer.py?hl=en-GB&answer=95346">Chrome</a> supports it properly.</p>
+        <p>This page needs a <a href="https://dvcs.w3.org/hg/audio/raw-file/tip/webaudio/specification.html">Web Audio API</a> enabled browser. 
+        Here is an updated list with browser support: <a href="http://caniuse.com/#feat=audio-api">Can I use</a.</p>
         <p>
             In order to use the microphone, you may have to enable a configuration flag:
             <ul>

--- a/static/pitch-shifter.html
+++ b/static/pitch-shifter.html
@@ -46,7 +46,7 @@
         <canvas width="512px" height="240px"></canvas>
 
         <p>This page needs a <a href="https://dvcs.w3.org/hg/audio/raw-file/tip/webaudio/specification.html">Web Audio API</a> enabled browser. 
-        Here is an updated list with browser support: <a href="http://caniuse.com/#feat=audio-api">Can I use</a.</p>
+        Here is an updated list with browser support: <a href="http://caniuse.com/#feat=audio-api">Can I use</a>.</p>
         <p>
             In order to use the microphone, you may have to enable a configuration flag:
             <ul>


### PR DESCRIPTION
There have been some changes made to the Web Audio API so I replaced:
- noteOn() -> start()
- webkitAudioContext -> AudioContext

I put everything in a branch called gh-pages so that people can get a live demo. (If my changes are merged, the link obviously needs to change to urtzurd.github.io/html-audio/static/pitch-shifter.html.) Another thing one could do is to move pitch-shifter.html to html-audio/index.html, then the live demo link becomes simpler: urtzurd.github.io/html-audio.

Updated some browser support info.
